### PR TITLE
Updated the check of the Yum Output Signature

### DIFF
--- a/check_yum
+++ b/check_yum
@@ -4,7 +4,7 @@
 """Nagios plugin to check the YUM package management system for package updates. Can optionally alert on any available updates as well as just security related updates."""
 
 __title__ = "check_yum"
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 #Standard Nagios return codes
 OK = 0
@@ -301,7 +301,7 @@ class YumTester:
 		
 		number_other_updates = number_total_updates - number_security_updates
 		
-		if len(output) > number_total_updates + 25:
+		if len(output) > ((number_total_updates * 2) + 25):
 			end(WARNING, "YUM output signature is larger than current known format, please make sure you have upgraded to the latest version of this plugin. If the problem persists, please contact the author for a fix")
 		
 		return number_security_updates, number_other_updates


### PR DESCRIPTION
I noted that the check_yum plugin began failing on all of my EL7 machines shortly after our latest patch cycle.  I found this to be due to the output of the yum check-update command wrapping the lines of several updates and then counting them as two.  I updated the check to allow for double the number of updates + 25 lines, thus allowing for a case where all output lines may be wrapped, plus the header info and enough space for a high number of repositories in the yum configuration to be listed at the beginning of the output.  This change is working well in our environment.
![check_yumupdate](https://cloud.githubusercontent.com/assets/4421198/11249074/be478a26-8df2-11e5-8301-2ab6298b9a28.png)



  