### PR TITLE
Fix check_yum for excluded packages in RHEL 7

### DIFF
--- a/check_yum
+++ b/check_yum
@@ -268,7 +268,10 @@ class YumTester:
 		re_no_security_updates_available_rhel5 = re.compile("No packages needed, for security, \d+ available")
 		re_no_security_updates_available_rhel6 = re.compile("No packages needed for security; \d+ packages available")
 		summary_line_found = False
+		excluded_packages_found = False
 		for line in output:
+			if "excluded" in line:
+				excluded_packages_found = True
 			if re_no_security_updates_available_rhel5.match(line):
 				summary_line_found = True
 				number_security_updates = 0
@@ -301,7 +304,7 @@ class YumTester:
 		
 		number_other_updates = number_total_updates - number_security_updates
 		
-		if len(output) > number_total_updates + 25:
+		if not excluded_packages_found and len(output) > number_total_updates + 25:
 			end(WARNING, "YUM output signature is larger than current known format, please make sure you have upgraded to the latest version of this plugin. If the problem persists, please contact the author for a fix")
 		
 		return number_security_updates, number_other_updates


### PR DESCRIPTION
In our case, there were lots of lines like `-->
libuuid-2.23.2-22.el7_1.i686 from rhel-7-server-rpms excluded
(updateinfo)` in the output of `yum --security check-update` which
triggered the test for `len(output) > number_total_updates + 25`.

This simply sets a flag when at least one entry like this is found and
then skips that test.

I am aware that this may falsely match when a package or repo are named
including something like excluded.