### PR TITLE
Deduct the excluded packages from the total output count

### DIFF
--- a/check_yum
+++ b/check_yum
@@ -268,6 +268,7 @@ class YumTester:
 		re_no_security_updates_available_rhel5 = re.compile("No packages needed, for security, \d+ available")
 		re_no_security_updates_available_rhel6 = re.compile("No packages needed for security; \d+ packages available")
 		summary_line_found = False
+		excluded = 0
 		for line in output:
 			if re_no_security_updates_available_rhel5.match(line):
 				summary_line_found = True
@@ -289,7 +290,9 @@ class YumTester:
 				number_security_updates = line.split()[0]
 				number_total_updates = line.split()[7]
 				break
-		
+			if "excluded (updateinfo)" in line:
+				excluded += 1
+
 		if not summary_line_found:
 			end(WARNING, "Cannot find summary line in YUM output. Please make sure you have upgraded to the latest version of this plugin. If the problem persists, please contact the author for a fix")
 		
@@ -301,7 +304,7 @@ class YumTester:
 		
 		number_other_updates = number_total_updates - number_security_updates
 		
-		if len(output) > number_total_updates + 25:
+		if ( len(output) - excluded ) > ( number_total_updates + 25 ):
 			end(WARNING, "YUM output signature is larger than current known format, please make sure you have upgraded to the latest version of this plugin. If the problem persists, please contact the author for a fix")
 		
 		return number_security_updates, number_other_updates


### PR DESCRIPTION
In RHEL/CentOS 7, the output from the command
`yum --security check-update` 
seems to list all the packages that has been excluded from
the check. This list is way too long and breaks the check_yum nagios plugin.