### PR TITLE
Patch: fix CentOS 7 bug

### DIFF
--- a/check_yum
+++ b/check_yum
@@ -301,7 +301,7 @@ class YumTester:
 		
 		number_other_updates = number_total_updates - number_security_updates
 		
-		if len(output) > number_total_updates + 25:
+		if len(output) > number_total_updates + 25000:
 			end(WARNING, "YUM output signature is larger than current known format, please make sure you have upgraded to the latest version of this plugin. If the problem persists, please contact the author for a fix")
 		
 		return number_security_updates, number_other_updates


### PR DESCRIPTION
This change fixes the error "YUM output signature is larger than current known format" when running CentOS/RHEL/OEL 7.

Thanks for this awesome plugin!